### PR TITLE
example: fix install target

### DIFF
--- a/example/example.pro
+++ b/example/example.pro
@@ -24,7 +24,5 @@ QML_IMPORT_PATH =
 # Additional import path used to resolve QML modules just for Qt Quick Designer
 QML_DESIGNER_IMPORT_PATH =
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /opt/$${TARGET}/bin
-!isEmpty(target.path): INSTALLS += target
+target.path = $$[QT_INSTALL_PREFIX]/bin
+INSTALLS += target


### PR DESCRIPTION
Install target must not explicitly set installation paths depending on the platform, because that break crss.compilatio and cross compilation. Indeed, the installation prefix for binaries must be taken from QT_INSTALL_PREFIX or passed to the make invocation with DESTDIR.

Signed-off-by: Angelo Compagnucci <angelo@amarulasolutions.com>