### PR TITLE
fix download issue

### DIFF
--- a/yocto-recipes/cutekeyboard_git.bb
+++ b/yocto-recipes/cutekeyboard_git.bb
@@ -7,6 +7,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2f6f4d4f7d76b223f08e17122d04010f"
 DEPENDS += "qtbase qtdeclarative qtmultimedia qtquickcontrols qtsvg qtxmlpatterns"
 
 SRCREV = "master"
-SRC_URI = "git://github.com/amarula/cutekeyboard.git;protocol=https"
+SRC_URI = "git://github.com/amarula/cutekeyboard.git;protocol=https;branch=${SRCREV}"
 
 QMAKE_PROFILES += "${S}/src/src.pro"


### PR DESCRIPTION
fix the following in yocto Kirkstone :
WARNING: URL: git://github.com/amarula/cutekeyboard.git;protocol=https does not set any branch parameter. The future default branch used by tools and repositories is uncertain and we will therefore soon require this is set in all git urls.