### PR TITLE
Added support for INSTALL_PREFIX in QMake project

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -34,6 +34,11 @@ INSTALLS += \
     target \
     deployment
 
+!defined(INSTALL_PREFIX, var):INSTALL_PREFIX = $$[QT_INSTALL_PREFIX]
+
+INSTALL_QML = $$INSTALL_PREFIX/$$relative_path($$[QT_INSTALL_QML], $$[QT_INSTALL_PREFIX])
+INSTALL_PLUGINS = $$INSTALL_PREFIX/$$relative_path($$[QT_INSTALL_PLUGINS], $$[QT_INSTALL_PREFIX])
+
 deployment.files = $$QML_FILES
-deployment.path = $$[QT_INSTALL_QML]/QtQuick/CuteKeyboard
-target.path = $$[QT_INSTALL_PLUGINS]/platforminputcontexts
+deployment.path = $$INSTALL_QML/QtQuick/CuteKeyboard
+target.path = $$INSTALL_PLUGINS/platforminputcontexts


### PR DESCRIPTION
Hi, 

we're using the keyboard in a Buildroot environment which executes `make install` on the packages to install them to the target rootfs. 

The current .pro tries to install the keyboard into the toolchain's sysroot, and it is not desired. 

The patch provides a new configuration variable INSTALL_PREFIX to override the installation path. If it is not specified, the installation is performed into the Qt installation directory as previously.

Example:
 
```
$ qmake CONFIG+=release INSTALL_PREFIX=/home/build/rootfs_custom
Project MESSAGE: This project is using private headers and will therefore be tied to this specific Qt module build version.
...
$ make 
...
$ make install
/opt/buildroot-imx8m/host/bin/qmake -install qinstall -exe libcutekeyboardplugin.so /home/build/rootfs_custom/plugins/platforminputcontexts/libcutekeyboardplugin.so
/opt/buildroot-imx8m/host/bin/qmake -install qinstall /home/build/workspace/cutekeyboard/src/qml/qmldir /home/build/rootfs_custom/qml/QtQuick/CuteKeyboard/qmldir
/opt/buildroot-imx8m/host/bin/qmake -install qinstall /home/build/workspace/cutekeyboard/src/qml/AlternativeKeysPopup.qml /home/build/rootfs_custom/qml/QtQuick/CuteKeyboard/AlternativeKeysPopup.qml
...
```

Cheers