### PR TITLE
Fixed typo in RuLayout.qml

### DIFF
--- a/src/qml/RuLayout.qml
+++ b/src/qml/RuLayout.qml
@@ -114,7 +114,7 @@ ColumnLayout {
             inputPanelRef: inputPanel
         }
 
-        Key {s            
+        Key {            
             btnText: "л"
             inputPanelRef: inputPanel
         }


### PR DESCRIPTION
deleted letter "s", it was preventing correct interpretation of Russian layout in runtime