### PR TITLE
Fix build with Qt 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Qml Quick)
 
+if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
+  find_package(Qt6 REQUIRED COMPONENTS GuiPrivate QuickPrivate)
+endif()
+
 option(BUILD_EXAMPLES "Build examples" OFF)
 
 if(QT_KNOWN_POLICY_QTP0001)


### PR DESCRIPTION
The private API has been extracted into a separate CMake package

See https://bugreports.qt.io/browse/QTBUG-87776