### PR TITLE
fix: inputPanel is not defined warning

### DIFF
--- a/src/qml/InputPanel.qml
+++ b/src/qml/InputPanel.qml
@@ -22,7 +22,7 @@ Item {
     property alias emptySpaceBar: layoutLoader.emptySpaceBar
 
     /*! \internal */
-    readonly property bool __isRootItem: inputPanel.parent !== null && inputPanel.parent.parent === null
+    readonly property bool __isRootItem: root.parent !== null && root.parent.parent === null
 
     function showKeyPopup(keyButton) {
         keyPopup.popup(keyButton, root);


### PR DESCRIPTION
Currently the code only works accidentally when you give your instantiation of `InputPanel` the id `inputPanel`.