### PR TITLE
Add auto-caps feature

### DIFF
--- a/src/DeclarativeInputEngine.cpp
+++ b/src/DeclarativeInputEngine.cpp
@@ -29,6 +29,7 @@ struct DeclarativeInputEnginePrivate {
     bool isUppercase{false};
     bool symbolMode{false};
     bool persistentUppercase{true};
+    bool autoCapitalize{false};
     QHash<DeclarativeInputEngine::InputLayouts, LayoutData> layoutFiles = {
         {DeclarativeInputEngine::En, {"EnLayout", "English"}},
         {DeclarativeInputEngine::Fr, {"FrLayout", "Français"}},
@@ -139,6 +140,17 @@ void DeclarativeInputEngine::setPersistentUppercase(bool persistentUppercase) {
     if (d->persistentUppercase != persistentUppercase) {
         d->persistentUppercase = persistentUppercase;
         emit isPersistentUppercaseChanged();
+    }
+}
+
+bool DeclarativeInputEngine::isAutoCapitalize() const {
+    return d->autoCapitalize;
+}
+
+void DeclarativeInputEngine::setAutoCapitalize(bool autoCapitalize) {
+    if (d->autoCapitalize != autoCapitalize) {
+        d->autoCapitalize = autoCapitalize;
+        emit isAutoCapitalizeChanged();
     }
 }
 

--- a/src/DeclarativeInputEngine.h
+++ b/src/DeclarativeInputEngine.h
@@ -32,6 +32,7 @@ class DeclarativeInputEngine : public QObject {
     Q_PROPERTY(bool uppercase READ isUppercase WRITE setUppercase NOTIFY isUppercaseChanged)
     Q_PROPERTY(bool symbolMode READ isSymbolMode WRITE setSymbolMode NOTIFY isSymbolModeChanged)
     Q_PROPERTY(bool persistentUppercase READ isPersistentUppercase WRITE setPersistentUppercase NOTIFY isPersistentUppercaseChanged)
+    Q_PROPERTY(bool autoCapitalize READ isAutoCapitalize WRITE setAutoCapitalize NOTIFY isAutoCapitalizeChanged)
     // clang-format on
 
    public:
@@ -116,6 +117,9 @@ class DeclarativeInputEngine : public QObject {
     bool isPersistentUppercase() const;
     void setPersistentUppercase(bool persistentUppercase);
 
+    bool isAutoCapitalize() const;
+    void setAutoCapitalize(bool autoCapitalize);
+
     Q_INVOKABLE bool inputLayoutValid(const QString &layout) const;
 
     /**
@@ -169,6 +173,8 @@ class DeclarativeInputEngine : public QObject {
     void isSymbolModeChanged();
 
     void isPersistentUppercaseChanged();
+
+    void isAutoCapitalizeChanged();
 
    private:
     DeclarativeInputEnginePrivate *d;

--- a/src/VirtualKeyboardInputContext.cpp
+++ b/src/VirtualKeyboardInputContext.cpp
@@ -173,7 +173,11 @@ void VirtualKeyboardInputContext::setFocusObject(QObject *object) {
     } else {
         d->InputEngine->setInputMode(DeclarativeInputEngine::Letters);
         d->InputEngine->setSymbolMode(false);
-        d->InputEngine->setUppercase(false);
+        // Auto-capitalize on focus if enabled, field is not password, and field is empty
+        bool shouldUppercase = d->InputEngine->isAutoCapitalize() &&
+                               !isPasswordField() &&
+                               surroundingText().isEmpty();
+        d->InputEngine->setUppercase(shouldUppercase);
     }
 
     QQuickItem *i = d->FocusItem;
@@ -187,6 +191,19 @@ void VirtualKeyboardInputContext::setFocusObject(QObject *object) {
     }
 
     ensureFocusedObjectVisible();
+}
+
+QString VirtualKeyboardInputContext::surroundingText() const {
+    if (!d->FocusItem)
+        return QString();
+    return d->FocusItem->inputMethodQuery(Qt::ImSurroundingText).toString();
+}
+
+bool VirtualKeyboardInputContext::isPasswordField() const {
+    if (!d->FocusItem)
+        return false;
+    Qt::InputMethodHints hints(d->FocusItem->inputMethodQuery(Qt::ImHints).toInt());
+    return (hints & Qt::ImhHiddenText) || (hints & Qt::ImhSensitiveData);
 }
 
 void VirtualKeyboardInputContext::ensureFocusedObjectVisible() {

--- a/src/VirtualKeyboardInputContext.h
+++ b/src/VirtualKeyboardInputContext.h
@@ -103,6 +103,16 @@ class VirtualKeyboardInputContext : public QPlatformInputContext {
      */
     Q_INVOKABLE void registerInputPanel(QObject *inputPanel);
 
+    /**
+     * Returns the surrounding text of the focused input field, or empty if none.
+     */
+    Q_INVOKABLE QString surroundingText() const;
+
+    /**
+     * Returns true if the focused input field is a password/hidden-text field.
+     */
+    Q_INVOKABLE bool isPasswordField() const;
+
    protected:
     /**
      * Protected constructor - use instance function to get the one and only

--- a/src/qml/InputPanel.qml
+++ b/src/qml/InputPanel.qml
@@ -21,6 +21,7 @@ Item {
     property var availableLanguageLayouts: ["En"]
     property alias emptySpaceBar: layoutLoader.emptySpaceBar
     property bool persistentShift: true
+    property bool autoCapitalize: false
     //! \internal
     readonly property bool __isRootItem: root.parent !== null && root.parent.parent === null
 
@@ -66,6 +67,7 @@ Item {
     }
     onLanguageLayoutChanged: loadLettersLayout()
     onPersistentShiftChanged: InputEngine.persistentUppercase = persistentShift
+    onAutoCapitalizeChanged: InputEngine.autoCapitalize = autoCapitalize
     Component.onCompleted: {
         InputContext.registerInputPanel(root);
         if (availableLanguageLayouts.length == 0)
@@ -85,6 +87,7 @@ Item {
         InputPanel.availableLanguageLayouts = availableLanguageLayouts;
         InputPanel.languageLayout = languageLayout;
         InputEngine.persistentUppercase = persistentShift;
+        InputEngine.autoCapitalize = autoCapitalize;
         loadLettersLayout();
     }
 

--- a/src/qml/Key.qml
+++ b/src/qml/Key.qml
@@ -47,8 +47,13 @@ Button {
     onReleased: {
         if (!functionKey) {
             InputEngine.virtualKeyClick(btnKey, InputEngine.uppercase ? btnText.toUpperCase() : btnText, InputEngine.uppercase ? Qt.ShiftModifier : 0);
-            if (!InputEngine.persistentUppercase)
-                InputEngine.uppercase = false;
+            var autoCapUp = false;
+            if (InputEngine.autoCapitalize && !InputContext.isPasswordField()) {
+                var surrounding = InputContext.surroundingText();
+                autoCapUp = surrounding.length === 0 || /[.!?] $/.test(surrounding);
+            }
+            if (!InputEngine.persistentUppercase || autoCapUp)
+                InputEngine.uppercase = autoCapUp;
         }
     }
 


### PR DESCRIPTION
This change enables Cutekeyboard to handle auto-capitalization. Meaning that empty text fields (that aren't passwords) would start with caps.

It extends the work made in https://github.com/amarula/cutekeyboard/pull/46 for the addition of `persistentShift`.