### PR TITLE
Add local dev paths for running example without installing plugin

### DIFF
--- a/example/example.pro
+++ b/example/example.pro
@@ -8,10 +8,7 @@ CONFIG += c++11
 # deprecated API to know how to port your code away from it.
 DEFINES += QT_DEPRECATED_WARNINGS
 
-# You can also make your code fail to compile if it uses deprecated APIs.
-# In order to do so, uncomment the following line.
-# You can also select to disable deprecated APIs only up to a certain version of Qt.
-#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+DEFINES += PLUGIN_BUILD_DIR=\\\"$$clean_path($$OUT_PWD/../src)\\\"
 
 SOURCES += \
         main.cpp

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -2,6 +2,10 @@
 #include <QQmlApplicationEngine>
 
 int main(int argc, char *argv[]) {
+    QString buildPluginDir = QStringLiteral(PLUGIN_BUILD_DIR);
+
+    QCoreApplication::addLibraryPath(buildPluginDir);
+
     qputenv("QT_IM_MODULE", QByteArray("cutekeyboard"));
 
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
@@ -9,7 +13,10 @@ int main(int argc, char *argv[]) {
     QGuiApplication app(argc, argv);
 
     QQmlApplicationEngine engine;
+
+    engine.addImportPath(buildPluginDir);
     engine.addImportPath(":/");
+
     const QUrl url(QStringLiteral("qrc:/main.qml"));
     QObject::connect(
         &engine, &QQmlApplicationEngine::objectCreated, &app,

--- a/src/src.pro
+++ b/src/src.pro
@@ -42,3 +42,12 @@ INSTALL_PLUGINS = $$INSTALL_PREFIX/$$relative_path($$[QT_INSTALL_PLUGINS], $$[QT
 deployment.files = $$QML_FILES
 deployment.path = $$INSTALL_QML/QtQuick/CuteKeyboard
 target.path = $$INSTALL_PLUGINS/platforminputcontexts
+
+contains(CONFIG, BUILD_EXAMPLES) {
+    # --- Local Development Configuration ---
+    DESTDIR = $$OUT_PWD/platforminputcontexts
+
+    mock_qml.files = $$PWD/qml/qmldir $$files($$PWD/qml/*.qml)
+    mock_qml.path  = $$OUT_PWD/QtQuick/CuteKeyboard
+    COPIES += mock_qml
+}


### PR DESCRIPTION
Define PLUGIN_BUILD_DIR in example.pro pointing to the src build output, and use it to register both the library and QML import paths at runtime. Configure src.pro to output the plugin to a local platforminputcontexts/ directory and copy QML files into place, mirroring the installed layout.