### PR TITLE
Close alternatives key popup on click to keyboard area

### DIFF
--- a/src/qml/InputPanel.qml
+++ b/src/qml/InputPanel.qml
@@ -116,6 +116,10 @@ Item {
         anchors.fill: parent
         propagateComposedEvents: false
         z: 99
+
+        onClicked: {
+            alternativesKeyPopup.visible = false;
+        }
     }
 
     Rectangle {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clicking outside the alternatives key popup now closes it as expected, improving the input panel’s behavior and reducing on-screen clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->